### PR TITLE
[DAT-22146] Rename master branch references to main

### DIFF
--- a/.github/workflows/test_springboot_liquibase_oracle.yml
+++ b/.github/workflows/test_springboot_liquibase_oracle.yml
@@ -1,4 +1,4 @@
-# This workflow will build a Java Springboot project with Maven, for the following project example: https://github.com/liquibase/liquibase-toolbox/tree/master/project_examples/liquibase-springboot/springboot_liquibase_oracle 
+# This workflow will build a Java Springboot project with Maven, for the following project example: https://github.com/liquibase/liquibase-toolbox/tree/main/project_examples/liquibase-springboot/springboot_liquibase_oracle 
 
 name: Springboot CI with Maven and Spring Liquibase integration 
 

--- a/project_examples/stored_logic_example/.github/workflows/liquibase_workflow2.yml
+++ b/project_examples/stored_logic_example/.github/workflows/liquibase_workflow2.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Running Liquibase Commands
       uses: actions/checkout@v2
     - run: |
-          curl -L https://raw.githubusercontent.com/liquibase/liquibase-toolbox/master/download_install_liquibase/download_liquibase.sh --output download_liquibase.sh
+          curl -L https://raw.githubusercontent.com/liquibase/liquibase-toolbox/main/download_install_liquibase/download_liquibase.sh --output download_liquibase.sh
           chmod +x download_liquibase.sh
           ./download_liquibase.sh
           ./liquibase/liquibase --version


### PR DESCRIPTION
## Summary
- Updated self-referencing URLs in two workflow files from `master` to `main` branch
- Part of the master-to-main branch migration effort

## Files Changed
- `.github/workflows/test_springboot_liquibase_oracle.yml` — updated comment URL pointing to this repo
- `project_examples/stored_logic_example/.github/workflows/liquibase_workflow2.yml` — updated raw.githubusercontent.com download URL

## Skipped References (not branch names)
- `init_db_environment_docker/create_sybase_container.sh` — Sybase database `master` references
- `project_examples/release_example/README.md` — "master changelog" (Liquibase concept)
- `project_examples/multi_schema_example/README.md` — "master changelog" (Liquibase concept)
- `project_examples/liquibase-cli/Sybase/masterDBChangeLog.xml` — Sybase database `master.dbo` references
- `.github/workflows/test_springboot_liquibase_oracle.yml` line 35 — `actions/upload-artifact@master` (external repo URL)

## Test plan
- [ ] Verify workflow files parse correctly
- [ ] Verify raw.githubusercontent.com URL resolves after branch rename

Jira: [DAT-22146](https://datical.atlassian.net/browse/DAT-22146)

🤖 Generated with [Claude Code](https://claude.com/claude-code)