### PR TITLE
TECHOPS-646: Pin step-level GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/run_scenarios.yml
+++ b/.github/workflows/run_scenarios.yml
@@ -23,7 +23,7 @@ jobs:
       
       - name: RunLiquibaseCLICommands
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       
       # Runs a set of commands using the runners shell
 
@@ -53,7 +53,7 @@ jobs:
     steps:
     - name: RunLiquibaseWithSpringboot
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - run: |
         cd project_examples/liquibase-springboot
         mvn clean package

--- a/.github/workflows/test_springboot_liquibase_oracle.yml
+++ b/.github/workflows/test_springboot_liquibase_oracle.yml
@@ -22,9 +22,9 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2
       with:
         java-version: '11'
         distribution: 'temurin'
@@ -32,7 +32,7 @@ jobs:
     - name: Build with Maven
       run: cd project_examples/liquibase-springboot/springboot_liquibase_oracle && mvn clean package -Dspring.datasource.url=jdbc:oracle:thin:@127.0.0.1:49161/xe -Dspring.datasource.username=system -Dspring.datasource.password=oracle -Dspring.liquibase.change-log=classpath:db/changelog/changelog_version-3.2.oracle.sql -Dserver.port=8086 -Duser.timezone=CST
       
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@0c366cb4fc8897159c94880f94b55bc716ad6a66 # master
       with:
         name: my-artifact
         path: project_examples/liquibase-springboot/springboot_liquibase_oracle/target/SalesManager-0.0.1-SNAPSHOT.jar


### PR DESCRIPTION
## 📋 Overview
Pins **step-level** `uses:` references to full-length commit SHAs, per the enterprise Actions SHA-pinning policy. Tracked in [TECHOPS-646](https://datical.atlassian.net/browse/TECHOPS-646) (relates to [TECHOPS-81](https://datical.atlassian.net/browse/TECHOPS-81)).

Step-level action references are enforced by **"Require actions to be pinned to a full-length commit SHA"**; job-level reusable-workflow refs (`*.yml@main`) are exempt. These refs were still pinned to tags/branches and would fail once enforcement is enabled.

## 🔧 Changes
- Replaced tag/branch refs with the resolved full commit SHA.
- Original ref preserved as a trailing `# <ref>` comment.
- Only active (non-commented) step-level references changed.

## ✅ Testing
- SHAs resolved via the GitHub API against current tag/branch HEAD.
- Post-change verification confirmed 0 remaining unpinned active step-level refs in the edited files.

## ⚠️ Notes
- No functional change: same action code, now immutably referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-646]: https://datical.atlassian.net/browse/TECHOPS-646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECHOPS-81]: https://datical.atlassian.net/browse/TECHOPS-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ